### PR TITLE
feat: 🎸 Updated Makefile deploy to depend on sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,10 @@ docker: docker_build
 docker_build:
 	docker build . --tag raptacon2022_build
 
-deploy:
+# Installs the 3rd party dependencies such as photonvision and rapatcon3200 (whatever is in the toml esp in the requires section)
+# https://docs.wpilib.org/en/stable/docs/software/python/pyproject_toml.html
+sync:
+	${PYTHON} -m robotpy sync
+
+deploy: sync
 	${PYTHON} -m robotpy deploy 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ TODO more documentation here around motors, controllers and how to update them.
 
 Once you have run the command "python -m robotpy sync" and have connected to the bot, run the command "python -m robotpy deploy" and it will run tests to check for any obvious errors. Then it will check for variations in packages and install any missing ones. Then it deploys the code to the bot.
 
+alternatively if you're using GitBash (or not on Windows) you can just run:
+
+```bash
+make sync
+```
+
+or 
+
+```bash
+make deploy
+```
+which calls sync as a dependency.
+
 If you don't have the driver station installed on your device, you need to do that. You can install it from [NI FRC tools](https://www.ni.com/en.html?cid=PSEA-7013q000001rC7dAAE-CONS-GOGSE_103579176918&utm_keyword=ni&gad_source=1&gclid=Cj0KCQiA-62tBhDSARIsAO7twbYEez351i8rN76k43uCC2MIVkMJ89hxuDBCPp60X1JldrEnka57xE8aApVcEALw_wcB) 
 
 # Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2024.3.2.1"
+robotpy_version = "2025.2.1"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]
@@ -25,7 +25,8 @@ robotpy_extras = [
     #"sim",
 ]
 # Other pip packages to install
+# Must use python -m robotpy sync to install to cache
 requires = [
     "photonlibpy",
+    "raptacon3200"
 ]
-raptacon3200 = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2025.2.1"
+robotpy_version = "2024.3.2.1"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]


### PR DESCRIPTION
This will now reliably install 3rd party libs like photonvision and raptcon3200 before deploying to bot
