### PR TITLE
Fixing Field Relative - Field-Relative Rotation

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,10 @@ from typing import Tuple
 
 
 class OperatorRobotConfig:
-    default_start_pose: Tuple[float] = (2.0, 7.0, 0.0)
+    # Default start position for red alliance
+    red_default_start_pose: Tuple[float] = (10.0, 1.5, 0.0)
+    # Default start position for blue alliance
+    blue_default_start_pose: Tuple[float] = (7.7, 6.0, 180.0)
     # Give in front-left, front-right, back-left, back-right order
     # ids for the drive controllers
     swerve_module_channels: Tuple[int] = (50, 53, 56, 59)

--- a/config.py
+++ b/config.py
@@ -3,9 +3,11 @@ from typing import Tuple
 
 
 class OperatorRobotConfig:
-    # Default start position for red alliance
+    # Default start position for red alliance using aways-blue-alliance coordinates
+    # Coordinates are x (meters), y (meeters), and rotation (degrees)
     red_default_start_pose: Tuple[float] = (10.0, 1.5, 0.0)
-    # Default start position for blue alliance
+    # Default start position for blue alliance using aways-blue-alliance coordinates
+    # Coordinates are x (meters), y (meeters), and rotation (degrees)
     blue_default_start_pose: Tuple[float] = (7.7, 6.0, 180.0)
     # Give in front-left, front-right, back-left, back-right order
     # ids for the drive controllers

--- a/config.py
+++ b/config.py
@@ -3,10 +3,10 @@ from typing import Tuple
 
 
 class OperatorRobotConfig:
-    # Default start position for red alliance using aways-blue-alliance coordinates
+    # Default start position for red alliance using always-blue-alliance coordinates
     # Coordinates are x (meters), y (meters), and rotation (degrees)
     red_default_start_pose: Tuple[float] = (10.0, 1.5, 0.0)
-    # Default start position for blue alliance using aways-blue-alliance coordinates
+    # Default start position for blue alliance using always-blue-alliance coordinates
     # Coordinates are x (meters), y (meters), and rotation (degrees)
     blue_default_start_pose: Tuple[float] = (7.7, 6.0, 180.0)
     # Give in front-left, front-right, back-left, back-right order

--- a/config.py
+++ b/config.py
@@ -4,10 +4,10 @@ from typing import Tuple
 
 class OperatorRobotConfig:
     # Default start position for red alliance using aways-blue-alliance coordinates
-    # Coordinates are x (meters), y (meeters), and rotation (degrees)
+    # Coordinates are x (meters), y (meters), and rotation (degrees)
     red_default_start_pose: Tuple[float] = (10.0, 1.5, 0.0)
     # Default start position for blue alliance using aways-blue-alliance coordinates
-    # Coordinates are x (meters), y (meeters), and rotation (degrees)
+    # Coordinates are x (meters), y (meters), and rotation (degrees)
     blue_default_start_pose: Tuple[float] = (7.7, 6.0, 180.0)
     # Give in front-left, front-right, back-left, back-right order
     # ids for the drive controllers

--- a/robotswerve.py
+++ b/robotswerve.py
@@ -74,6 +74,8 @@ class RobotSwerve:
         self.auto_command = self.auto_chooser.getSelected()
         if self.auto_command:
             self.auto_command.schedule()
+        else:
+            self.drivetrain.reset_pose_estimator(self.drivetrain.get_default_starting_pose())
 
     def autonomousPeriodic(self):
         pass

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -96,7 +96,7 @@ class SwerveDrivetrain(Subsystem):
             self.starting_pose
         )
 
-        self.reset_heading()
+        self.reset_heading(reset_pose_estimator=False)
 
         # Path Planner setup
         path_planner_config = RobotConfig.fromGUISettings()
@@ -143,7 +143,7 @@ class SwerveDrivetrain(Subsystem):
         """
         self.heading_offset = self.gyroscope.getRotation3d()
 
-    def reset_heading(self) -> None:
+    def reset_heading(self, reset_pose_estimator: bool = True) -> None:
         """
         Reset the heading such that the robot's current gyroscope reading will correspond to 0 in any
         heading and yaw readings after this method is called. Odometry must also be reset with a rotation
@@ -153,7 +153,8 @@ class SwerveDrivetrain(Subsystem):
             None: object's heading offset is updated in-place and pose estimator is reset
         """
         self.heading_offset = self.raw_current_heading()
-        self.reset_pose_estimator(Pose2d(self.current_pose().translation(), Rotation2d()))
+        if reset_pose_estimator:
+            self.reset_pose_estimator(Pose2d(self.current_pose().translation(), Rotation2d()))
 
     def drive(
         self,

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -96,7 +96,7 @@ class SwerveDrivetrain(Subsystem):
             self.starting_pose
         )
 
-        self.reset_heading(reset_pose_estimator=False)
+        self.reset_heading()
 
         # Path Planner setup
         path_planner_config = RobotConfig.fromGUISettings()
@@ -143,7 +143,7 @@ class SwerveDrivetrain(Subsystem):
         """
         self.heading_offset = self.gyroscope.getRotation3d()
 
-    def reset_heading(self, reset_pose_estimator: bool = True) -> None:
+    def reset_heading(self) -> None:
         """
         Reset the heading such that the robot's current gyroscope reading will correspond to 0 in any
         heading and yaw readings after this method is called. Odometry must also be reset with a rotation
@@ -153,8 +153,7 @@ class SwerveDrivetrain(Subsystem):
             None: object's heading offset is updated in-place and pose estimator is reset
         """
         self.heading_offset = self.raw_current_heading()
-        if reset_pose_estimator:
-            self.reset_pose_estimator(Pose2d(self.current_pose().translation(), Rotation2d()))
+        self.reset_pose_estimator(Pose2d(self.current_pose().translation(), Rotation2d()))
 
     def drive(
         self,

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -24,11 +24,8 @@ class SwerveDrivetrain(Subsystem):
     Virtual representation of, and interface for, a full swerve drive
     """
     def __init__(
-        self,
-        starting_pose: Pose2d = Pose2d(
-            Translation2d(*OperatorRobotConfig.default_start_pose[0:2]),
-            Rotation2d.fromDegrees(OperatorRobotConfig.default_start_pose[2])
-        )) -> None:
+        self
+        ):
         """
         Creates a new swerve drivetrain
 
@@ -86,9 +83,11 @@ class SwerveDrivetrain(Subsystem):
         self.heading_offset = Rotation3d()
         self.factory_default_gyro()
         if self.flip_to_red_alliance():
-            self.starting_pose = 180
+            self.starting_pose = Pose2d(Translation2d(*OperatorRobotConfig.red_default_start_pose[0:2]),
+            Rotation2d.fromDegrees(OperatorRobotConfig.red_default_start_pose[2]))
         else:
-            self.starting_pose = 0
+            self.starting_pose = Pose2d(Translation2d(*OperatorRobotConfig.blue_default_start_pose[0:2]),
+            Rotation2d.fromDegrees(OperatorRobotConfig.blue_default_start_pose[2]))
 
         self.pose_estimator = SwerveDrive4PoseEstimator(
             self.drive_kinematics,
@@ -180,9 +179,9 @@ class SwerveDrivetrain(Subsystem):
             None: individual swerve modules are given new goal states to transition to in-place
         """
         if field_relative:
-            field_invert = 1
+            field_invert = -1
             if self.flip_to_red_alliance():
-                field_invert = -1
+                field_invert = 1
 
             chassis_speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
                 field_invert * velocity_vector_x, field_invert * velocity_vector_y, angular_velocity, self.current_pose().rotation()

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -179,9 +179,9 @@ class SwerveDrivetrain(Subsystem):
             None: individual swerve modules are given new goal states to transition to in-place
         """
         if field_relative:
-            field_invert = -1
+            field_invert = 1
             if self.flip_to_red_alliance():
-                field_invert = 1
+                field_invert = -1
 
             chassis_speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
                 field_invert * velocity_vector_x, field_invert * velocity_vector_y, angular_velocity, self.current_pose().rotation()

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -25,11 +25,7 @@ class SwerveDrivetrain(Subsystem):
     """
     def __init__(self):
         """
-        Creates a new swerve drivetrain
-
-        Args:
-            starting_pose: the position and orientation of the robot on the field
-                at the moment the robot is first enabled
+        Creates a new swerve drivetrain.
 
         Returns:
             None: class initialization executed upon construction

--- a/subsystem/drivetrain/swerve_drivetrain.py
+++ b/subsystem/drivetrain/swerve_drivetrain.py
@@ -85,15 +85,18 @@ class SwerveDrivetrain(Subsystem):
         self.gyroscope = navx.AHRS.create_spi()
         self.heading_offset = Rotation3d()
         self.factory_default_gyro()
+        if self.flip_to_red_alliance():
+            self.starting_pose = 180
+        else:
+            self.starting_pose = 0
 
         self.pose_estimator = SwerveDrive4PoseEstimator(
             self.drive_kinematics,
             self.current_yaw(),
             self.current_module_positions(),
-            starting_pose
+            self.starting_pose
         )
 
-        self.starting_pose = starting_pose
         self.reset_heading()
 
         # Path Planner setup
@@ -182,7 +185,7 @@ class SwerveDrivetrain(Subsystem):
                 field_invert = -1
 
             chassis_speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
-                field_invert * velocity_vector_x, field_invert * velocity_vector_y, angular_velocity, self.current_yaw()
+                field_invert * velocity_vector_x, field_invert * velocity_vector_y, angular_velocity, self.current_pose().rotation()
             )
         else:
             chassis_speeds = ChassisSpeeds(velocity_vector_x, velocity_vector_y, angular_velocity)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issue(s)
Field relative was not working correctly for both alliances. This was due to using a robot-relative yaw instead of a field-relative rotation.

## Steps to Test
1. Deploy on robot and open driver station
2. Turn on blue alliance and run a "none" auto
3. Check translation and rotation direction on joystick
4. Turn on red alliance, restart robot code, and run a "none" auto
5. Check translation and rotation direction on joystick

Confirmed functional at Colorado scrimmage on Sparky.

## Changelog

- Made separate default starting poses for each alliance
- Fixed field relative rotational read

## What?

Switched from using gryo yaw (which is robot-relative) to odometry rotation (which is field-relative)

## Why?

Make field relative fully usable




