### PR TITLE
Telemetry - Enhanced AdvantageScope visuals

### DIFF
--- a/robotswerve.py
+++ b/robotswerve.py
@@ -67,7 +67,7 @@ class RobotSwerve:
 
     def robotPeriodic(self):
         if self.enableTelemetry and self.telemetry:
-            self.telemetry.runDataCollections()
+            self.telemetry.runDefaultDataCollections()
 
     def disabledInit(self):
         self.drivetrain.set_motor_stop_modes(to_drive=True, to_break=True, all_motor_override=True, burn_flash=False)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Associated Issue(s)
Issue: https://github.com/Raptacon/Robot-2025/issues/119

## Steps to Test

1. Connect driver station to robot
2. Open AdvantageScope, and if needed go to Help > Preferences and set your team number
3. Connect to the robot in AdvantageScope
4. Run the robot and examine the odometry, swerve, and joystick tabs in AdvantageScope

## Changelog

- Logged robot odometry and target pose using serialized Pose2d struct objects
- Turned on driver station logging for controller overlay viewing
- Logged swerve module states, velocities, and rotation for swerve drivetrain viewer

## What?

- Logging specific data structures allows enhanced viewing of certain aspects of the robot in AdvantageScope. Because of the nature of the datatypes being logged, these are best persisted using NetworkTables.

## Why?

- Better testing, debugging, and retrospectives for drivetrain operation on a running robot
